### PR TITLE
관리자 통계 페이지 수정 및 API 연결

### DIFF
--- a/src/constants/mocks/adminStaticsMockData.ts
+++ b/src/constants/mocks/adminStaticsMockData.ts
@@ -8,14 +8,24 @@ export interface VehicleStatistic {
   maxSpeed: string;
 }
 
-export interface BizStatistic {
+export interface BizList {
   id: string;
-  name: string;
-  totalVehicles: number;
-  activeVehicles: number;
-  totalRentals: number;
-  totalDistance: string;
-  averageRating: number;
+  bizName: string;
+  totalCarCount: number;
+  drivingCarCount: number;
+  skipCount: number;
+}
+
+export interface BizStatistic {
+  dailyDriveCount: number;
+  dailyDriveDistance: number;
+  dailyDriveSec: number;
+}
+
+export interface MonthlyDriveCounts {
+  year: number;
+  month: number;
+  driveCount: number;
 }
 
 export interface OverallStatistic {
@@ -63,33 +73,40 @@ export const vehicleStatistics: VehicleStatistic[] = [
   },
 ];
 
-export const bizStatistics: BizStatistic[] = [
+export const bizListMock: BizList[] = [
   {
     id: "1",
-    name: "서울렌트카",
-    totalVehicles: 25,
-    activeVehicles: 20,
-    totalRentals: 156,
-    totalDistance: "12,456km",
-    averageRating: 4.8,
+    bizName: "서울렌트카",
+    totalCarCount: 25,
+    drivingCarCount: 20,
+    skipCount: 4,
   },
   {
     id: "2",
-    name: "부산렌트카",
-    totalVehicles: 18,
-    activeVehicles: 15,
-    totalRentals: 98,
-    totalDistance: "8,745km",
-    averageRating: 4.6,
+    bizName: "부산렌트카",
+    totalCarCount: 18,
+    drivingCarCount: 15,
+    skipCount: 6,
   },
   {
     id: "3",
-    name: "대구렌트카",
-    totalVehicles: 15,
-    activeVehicles: 12,
-    totalRentals: 87,
-    totalDistance: "7,123km",
-    averageRating: 4.7,
+    bizName: "대구렌트카",
+    totalCarCount: 15,
+    drivingCarCount: 12,
+    skipCount: 5,
+  },
+];
+
+export const bizStatisticMock: BizStatistic = {
+    dailyDriveCount: 1,
+    dailyDriveDistance: 5252.1,
+    dailyDriveSec: 304
+  };
+
+export const monthlyDriveCountsMock: MonthlyDriveCounts[] = [
+  {
+    date: new Date(),
+    driveCount: 0
   },
 ];
 

--- a/src/constants/mocks/adminStaticsMockData.ts
+++ b/src/constants/mocks/adminStaticsMockData.ts
@@ -1,3 +1,5 @@
+import { CarTypeEnum, CarTypes } from "../types/types";
+
 export interface VehicleStatistic {
   id: string;
   carNumber: string;
@@ -38,6 +40,11 @@ export interface CarCount {
   carCount: number;
 }
 
+export interface CarTypeCount {
+  carType: CarTypeEnum;
+  carTypeCount: number;
+}
+
 export interface OperationRate {
   bizName: string;
   rate: number;
@@ -50,6 +57,7 @@ export interface NonOperatedCar {
 
 export interface GraphStats {
   carCountWithBizName: CarCount[];
+  carTypeCounts: CarTypeCount[];
   operationRateWithBizName: OperationRate[];
   nonOperatedCarWithBizName: NonOperatedCar[];
 }
@@ -180,6 +188,13 @@ export const graphStatsMock: GraphStats = {
     { bizName: '토자렌트', carCount: 40},
     { bizName: '준시스템', carCount: 70},
     { bizName: '김치진주', carCount: 40},
+  ],
+  carTypeCounts : [
+    { carType: 'MINI', carTypeCount: 10 },
+    { carType: 'SEDAN', carTypeCount: 20 },
+    { carType: 'SUV', carTypeCount: 5 },
+    { carType: 'BUS', carTypeCount: 3 },
+    { carType: 'ETC', carTypeCount: 15 },
   ],
   operationRateWithBizName : [
     { bizName: '지원컴퍼니', rate: 82 },

--- a/src/constants/mocks/adminStaticsMockData.ts
+++ b/src/constants/mocks/adminStaticsMockData.ts
@@ -28,6 +28,32 @@ export interface MonthlyDriveCounts {
   driveCount: number;
 }
 
+export interface HourlyDriveCounts {
+  hour: number;
+  driveCount: number;
+}
+
+export interface CarCount {
+  bizName: string;
+  carCount: number;
+}
+
+export interface OperationRate {
+  bizName: string;
+  rate: number;
+}
+
+export interface NonOperatedCar {
+  bizName: string;
+  nonOperatedCarCount: number;
+}
+
+export interface GraphStats {
+  carCountWithBizName: CarCount[];
+  operationRateWithBizName: OperationRate[];
+  nonOperatedCarWithBizName: NonOperatedCar[];
+}
+
 export interface OverallStatistic {
   totalVehicles: number;
   activeVehicles: number;
@@ -105,10 +131,74 @@ export const bizStatisticMock: BizStatistic = {
 
 export const monthlyDriveCountsMock: MonthlyDriveCounts[] = [
   {
-    date: new Date(),
-    driveCount: 0
+    year: 2025,
+    month: 1,
+    driveCount: 30
+  },
+  {
+    year: 2025,
+    month: 2,
+    driveCount: 40
+  },
+  {
+    year: 2025,
+    month: 3,
+    driveCount: 50
+  },
+  {
+    year: 2025,
+    month: 4,
+    driveCount: 40
+  },
+  {
+    year: 2025,
+    month: 5,
+    driveCount: 60
   },
 ];
+
+export const hourlyDriveCountsMock: HourlyDriveCounts[] = [
+  { hour: 0, driveCount: 10 },
+  { hour: 1, driveCount: 20 },
+  { hour: 2, driveCount: 30 },
+  { hour: 3, driveCount: 60 },
+  { hour: 4, driveCount: 50 },
+  { hour: 5, driveCount: 70 },
+  { hour: 6, driveCount: 30 },
+  { hour: 7, driveCount: 40 },
+  { hour: 8, driveCount: 20 },
+  { hour: 9, driveCount: 10 },
+  { hour: 10, driveCount: 0 },
+  { hour: 11, driveCount: 50 },
+];
+
+export const graphStatsMock: GraphStats = {
+  carCountWithBizName : [
+    { bizName: '지원컴퍼니', carCount: 50}, 
+    { bizName: '지니카', carCount: 30}, 
+    { bizName: '부릉세상', carCount: 20}, 
+    { bizName: '토자렌트', carCount: 40},
+    { bizName: '준시스템', carCount: 70},
+    { bizName: '김치진주', carCount: 40},
+  ],
+  operationRateWithBizName : [
+    { bizName: '지원컴퍼니', rate: 82 },
+    { bizName: '지니카',     rate: 75 },
+    { bizName: '부릉세상',   rate: 68 },
+    { bizName: '토자렌트',   rate: 90 },
+    { bizName: '준시스템',   rate: 55 },
+    { bizName: '김치진주',   rate: 60 },
+  ],
+  
+  nonOperatedCarWithBizName : [
+    { bizName: '지원컴퍼니', nonOperatedCarCount: 9 },
+    { bizName: '지니카',     nonOperatedCarCount: 7 },
+    { bizName: '부릉세상',   nonOperatedCarCount: 6 },
+    { bizName: '토자렌트',   nonOperatedCarCount: 4 },
+    { bizName: '준시스템',   nonOperatedCarCount: 31 },
+    { bizName: '김치진주',   nonOperatedCarCount: 16 },
+  ],
+}
 
 export const overallStatistics: OverallStatistic = {
   totalVehicles: 58,

--- a/src/constants/types/types.ts
+++ b/src/constants/types/types.ts
@@ -80,6 +80,7 @@ export type CarDetailTypes = {
   deviceInfo: Devices;
   createdAt: string;
 };
+export type CarTypeEnum = "MINI" | "SEDAN" | "VAN" | "SUV" | "TRUCK" | "BUS" | "SPORTS" | "ETC";
 
 export type CarStatusEnum = "RUNNING" | "WAITING" | "FIXING" | "CLOSED";
 

--- a/src/libs/apis/adminStatisticApi.ts
+++ b/src/libs/apis/adminStatisticApi.ts
@@ -1,0 +1,76 @@
+import { format } from "date-fns";
+import api from "./api";
+
+export interface DailyStatisticSummary {
+  totalCarCount: number;
+  dailyDriveCarCount: number;
+  averageOperationRate: number;
+  totalDrivingSeconds: number;
+  totalDriveCount: number;
+  totalDrivingDistanceKm: number;
+}
+
+export interface HourlyStats {
+  hour: number;
+  driveCount: number;
+}
+
+export interface DailyStatisticResponse {
+  summary: DailyStatisticSummary;
+  hourlyStats: HourlyStats[];
+}
+
+export interface MonthlyStatisticSummary {
+  totalCarCount: number;
+  nonOperatingCarCount: number;
+  averageOperationRate: number;
+  totalDrivingSeconds: number;
+  totalDriveCount: number;
+  totalDrivingDistanceKm: number;
+}
+
+export interface MonthlyStat {
+  month: number;
+  driveCount: number;
+  driveDistance: number;
+}
+
+export interface MonthlyStatisticResponse {
+  summary: MonthlyStatisticSummary;
+  monthlyStat: MonthlyStat[];
+}
+
+const adminStatisticApiRoot = "/admin/statistic";
+
+export const adminStatisticApiService = {
+  getAdminBizList: async () => {
+    try {
+      const response = await api.get(`${adminStatisticApiRoot}/biz`);
+      return response.data.data;
+    } catch (error) {
+      console.warn("관리자 - 업체 목록 API 요청 실패", error);
+    }
+  },
+  getAdminBizStatistic: async (bizName: string, selectedDate: Date | undefined) => {
+    if(selectedDate == undefined) selectedDate = new Date();
+    try {
+        const formattedDate = format(selectedDate, "yyyy-MM-dd");
+        const response = await api.get(`${adminStatisticApiRoot}/biz/stat?bizName=${bizName}&selectedDate=${formattedDate}`);
+        return response.data.data;
+    } catch (error) {
+        console.warn('관리자 - 업체별 운행량 통계 API 요청 실패', error);
+    }   
+  },
+  getMonthlyDriveCounts: async (bizName: string, selectedDate: Date | undefined) => {
+    if(selectedDate == undefined) selectedDate = new Date();
+    try {
+        const formattedDate = format(selectedDate, "yyyy-MM-dd");
+        const response = await api.get(`${adminStatisticApiRoot}/monthly?bizName=${bizName}&selectedDate=${formattedDate}`);
+        return response.data.data;
+    } catch (error) {
+        console.warn('관리자 - 월별 운행량 통계 API 요청 실패', error);
+    }
+  }
+};
+
+export default adminStatisticApiService;

--- a/src/libs/apis/adminStatisticApi.ts
+++ b/src/libs/apis/adminStatisticApi.ts
@@ -51,6 +51,7 @@ export const adminStatisticApiService = {
       console.warn("관리자 - 업체 목록 API 요청 실패", error);
     }
   },
+
   getAdminBizStatistic: async (bizName: string, selectedDate: Date | undefined) => {
     if(selectedDate == undefined) selectedDate = new Date();
     try {
@@ -61,6 +62,7 @@ export const adminStatisticApiService = {
         console.warn('관리자 - 업체별 운행량 통계 API 요청 실패', error);
     }   
   },
+
   getMonthlyDriveCounts: async (bizName: string, selectedDate: Date | undefined) => {
     if(selectedDate == undefined) selectedDate = new Date();
     try {
@@ -70,7 +72,29 @@ export const adminStatisticApiService = {
     } catch (error) {
         console.warn('관리자 - 월별 운행량 통계 API 요청 실패', error);
     }
-  }
+  },
+
+  getHourlyDriveCounts: async (bizName: string, selectedDate: Date | undefined) => {
+    if(selectedDate == undefined) selectedDate = new Date();
+    try {
+        const formattedDate = format(selectedDate, 'yyyy-MM-dd');
+        const response = await api.get(`${adminStatisticApiRoot}/hourly?bizName=${bizName}&selectedDate=${formattedDate}`);
+        console.log('관리자 - 시간별 운행량 통계 API 요청 성공', response.data);
+        return response.data.data;
+    } catch (error) {
+        console.warn('관리자 - 시간별 운행량 통계 API 요청 실패', error);
+    }
+  },
+
+  getGraphStats: async () => {
+    try {
+        const response = await api.get(`${adminStatisticApiRoot}/graphs`);
+        console.log('관리자 - 그래프 통계 API 요청 성공', response.data.data);
+        return response.data.data;
+    } catch (error) {
+        console.warn('관리자 - 그래프 통계 API 요청 실패', error);
+    }
+  },
 };
 
 export default adminStatisticApiService;

--- a/src/pages/admin/statistic/AdminStatisticSection.tsx
+++ b/src/pages/admin/statistic/AdminStatisticSection.tsx
@@ -9,31 +9,23 @@ import BizStatisticTable from "./BizStatisticTable";
 import StatisticCharts from "./StatisticCharts";
 import MonthlyDriveCountChart from "./MonthlyDriveCountChart";
 
-// import {
-//   BizList,
-//   bizListMock,
-//   bizRatingDistribution,
-//   BizStatistic,
-//   bizStatistics,
-//   dailyActiveUsersData,
-//   monthlyRentalData,
-//   overallStatistics,
-//   vehicleStatistics,
-//   vehicleTypeDistribution,
-// } from "@/constants/mocks/adminStaticsMockData";
-
 import adminStatisticApiService from "@/libs/apis/adminStatisticApi";
-import { BizList, bizListMock, bizRatingDistribution, BizStatistic, bizStatisticMock, dailyActiveUsersData, MonthlyDriveCounts, monthlyDriveCountsMock, monthlyRentalData, vehicleTypeDistribution } from "@/constants/mocks/adminStaticsMockData";
+import { BizList, bizListMock, bizRatingDistribution, BizStatistic, bizStatisticMock, dailyActiveUsersData, GraphStats, graphStatsMock, HourlyDriveCounts, hourlyDriveCountsMock, MonthlyDriveCounts, monthlyDriveCountsMock, monthlyRentalData, vehicleTypeDistribution } from "@/constants/mocks/adminStaticsMockData";
+import DailyStatisticCharts from "./DailyStatisticCharts";
 
 function AdminStatisticSection() {
+  
+  const [isLoading, setIsLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [selectedBiz, setSelectedBiz] = useState("");
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+
   const [bizList, setBizList] = useState<BizList[]>(bizListMock);
   const [bizStatistic, setBizStatistic] = useState<BizStatistic>(bizStatisticMock);
   const [monthlyDriveCounts, setMonthlyDriveCounts] = useState<MonthlyDriveCounts[]>(monthlyDriveCountsMock);
-  const [isLoading, setIsLoading] = useState(false);
-  const [selectedBiz, setSelectedBiz] = useState("");
-
+  const [hourlyDriveCounts, setHourlyDriveCounts] = useState<HourlyDriveCounts[]>(hourlyDriveCountsMock);
+  const [graphStats, setGraphStats] = useState<GraphStats>(graphStatsMock);
+  
   const formatSeconds = (seconds: number) => {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
@@ -49,11 +41,16 @@ function AdminStatisticSection() {
 
         const bizStatistic = await adminStatisticApiService.getAdminBizStatistic(selectedBiz, selectedDate);
         setBizStatistic(bizStatistic);
-
+        
         const monthlyDriveCounts = await adminStatisticApiService.getMonthlyDriveCounts(selectedBiz, selectedDate);
         setMonthlyDriveCounts(monthlyDriveCounts);
-        console.log('monthlyDriveCounts', monthlyDriveCounts);
 
+        const hourlyDriveCounts = await adminStatisticApiService.getHourlyDriveCounts(selectedBiz, selectedDate);
+        setHourlyDriveCounts(hourlyDriveCounts);
+
+        const graphStats = await adminStatisticApiService.getGraphStats();
+        setGraphStats(graphStats);
+        
       } catch (error) {
         console.error("업체 목록 불러오기 실패", error);
       } finally {
@@ -69,8 +66,8 @@ function AdminStatisticSection() {
         <h1 className="text-3xl font-bold">업체별 통계 대시보드</h1>
       </div>
 
-      <BizStatisticTable 
-        data={bizList} 
+      <BizStatisticTable
+        data={bizList}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm} 
         selectedBiz={selectedBiz}
@@ -79,7 +76,12 @@ function AdminStatisticSection() {
         setSelectedDate={setSelectedDate} 
       />
       <BizMonthlyCardStatistic summary={bizStatistic} formatSeconds={formatSeconds} />
-      <MonthlyDriveCountChart data={monthlyDriveCounts} />
+      <MonthlyDriveCountChart 
+        monthlyData={monthlyDriveCounts}
+        hourlyData={hourlyDriveCounts}
+        selectedBiz={selectedBiz}
+        selectedDate={selectedDate}
+      />
 
       <h1 className="text-3xl font-bold">총 업체 통계</h1>
       {/* <Card>
@@ -96,10 +98,11 @@ function AdminStatisticSection() {
       </Card> */}
 
       <StatisticCharts
-        monthlyRentalData={monthlyRentalData}
-        dailyActiveUsersData={dailyActiveUsersData}
-        vehicleTypeDistribution={vehicleTypeDistribution}
-        bizRatingDistribution={bizRatingDistribution}
+        // monthlyRentalData={monthlyRentalData}
+        // dailyActiveUsersData={dailyActiveUsersData}
+        // vehicleTypeDistribution={vehicleTypeDistribution}
+        // bizRatingDistribution={bizRatingDistribution}
+        graphStats={graphStats}
       />
     </div>
   );

--- a/src/pages/admin/statistic/AdminStatisticSection.tsx
+++ b/src/pages/admin/statistic/AdminStatisticSection.tsx
@@ -4,65 +4,64 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 
-import DailyStatisticCharts from "./DailyStatisticCharts";
 import BizMonthlyCardStatistic from "./BizMonthlyCardStatistic";
 import BizStatisticTable from "./BizStatisticTable";
 import StatisticCharts from "./StatisticCharts";
-import VehicleStatisticTable from "./VehicleStatisticTable";
 import MonthlyDriveCountChart from "./MonthlyDriveCountChart";
 
-import {
-  bizRatingDistribution,
-  bizStatistics,
-  dailyActiveUsersData,
-  monthlyRentalData,
-  overallStatistics,
-  vehicleStatistics,
-  vehicleTypeDistribution,
-} from "@/constants/mocks/adminStaticsMockData";
+// import {
+//   BizList,
+//   bizListMock,
+//   bizRatingDistribution,
+//   BizStatistic,
+//   bizStatistics,
+//   dailyActiveUsersData,
+//   monthlyRentalData,
+//   overallStatistics,
+//   vehicleStatistics,
+//   vehicleTypeDistribution,
+// } from "@/constants/mocks/adminStaticsMockData";
 
-import { DailyStatisticResponse, statisticApiService } from "@/libs/apis/statisticApi";
+import adminStatisticApiService from "@/libs/apis/adminStatisticApi";
+import { BizList, bizListMock, bizRatingDistribution, BizStatistic, bizStatisticMock, dailyActiveUsersData, MonthlyDriveCounts, monthlyDriveCountsMock, monthlyRentalData, vehicleTypeDistribution } from "@/constants/mocks/adminStaticsMockData";
 
 function AdminStatisticSection() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedDate, setSelectedDate] = useState(new Date());
-  const [dailyData, setDailyData] = useState<DailyStatisticResponse | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+  const [bizList, setBizList] = useState<BizList[]>(bizListMock);
+  const [bizStatistic, setBizStatistic] = useState<BizStatistic>(bizStatisticMock);
+  const [monthlyDriveCounts, setMonthlyDriveCounts] = useState<MonthlyDriveCounts[]>(monthlyDriveCountsMock);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedBiz, setSelectedBiz] = useState("");
-
-  console.log(selectedBiz);
-  // 임시 summary 데이터 (API 연동 가능)
-  const monthlySummary = {
-    totalDriveCount: 1423,
-    totalDrivingSeconds: 58320,
-    totalDrivingDistanceKm: 2191.3,
-  };
 
   const formatSeconds = (seconds: number) => {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
     return `${hours}시간 ${minutes}분`;
   };
-  const monthlyData = {
-    labels: ["1월", "2월", "3월", "4월", "5월", "6월"],
-    values: [32, 45, 38, 52, 49, 60],
-  };
 
   useEffect(() => {
-    const fetchDailyData = async () => {
+    const fetchadminStatistic = async () => {
       setIsLoading(true);
       try {
-        const data = await statisticApiService.getDailyStatistic(selectedDate);
-        setDailyData(data);
+        const bizList = await adminStatisticApiService.getAdminBizList();
+        setBizList(bizList);
+
+        const bizStatistic = await adminStatisticApiService.getAdminBizStatistic(selectedBiz, selectedDate);
+        setBizStatistic(bizStatistic);
+
+        const monthlyDriveCounts = await adminStatisticApiService.getMonthlyDriveCounts(selectedBiz, selectedDate);
+        setMonthlyDriveCounts(monthlyDriveCounts);
+        console.log('monthlyDriveCounts', monthlyDriveCounts);
+
       } catch (error) {
-        console.error("일간 통계 로드 실패:", error);
+        console.error("업체 목록 불러오기 실패", error);
       } finally {
         setIsLoading(false);
       }
     };
-
-    fetchDailyData();
-  }, [selectedDate]);
+    fetchadminStatistic();
+  }, [selectedBiz, selectedDate]);
 
   return (
     <div className="space-y-6 p-6">
@@ -70,12 +69,20 @@ function AdminStatisticSection() {
         <h1 className="text-3xl font-bold">업체별 통계 대시보드</h1>
       </div>
 
-      <BizStatisticTable data={bizStatistics} setSelectedBiz={setSelectedBiz} />
-      <BizMonthlyCardStatistic summary={monthlySummary} formatSeconds={formatSeconds} />
-      <MonthlyDriveCountChart data={monthlyData} />
+      <BizStatisticTable 
+        data={bizList} 
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm} 
+        selectedBiz={selectedBiz}
+        setSelectedBiz={setSelectedBiz}
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate} 
+      />
+      <BizMonthlyCardStatistic summary={bizStatistic} formatSeconds={formatSeconds} />
+      <MonthlyDriveCountChart data={monthlyDriveCounts} />
 
       <h1 className="text-3xl font-bold">총 업체 통계</h1>
-      <Card>
+      {/* <Card>
         <CardHeader>
           <CardTitle>전일 시간별 운행량</CardTitle>
         </CardHeader>
@@ -83,10 +90,10 @@ function AdminStatisticSection() {
           {isLoading ? (
             <div className="text-center text-sm text-gray-500">로딩 중...</div>
           ) : (
-            <DailyStatisticCharts selectedDate={selectedDate} dailyData={dailyData} />
+            <DailyStatisticCharts selectedDate={selectedDate} dailyData={bizList} />
           )}
         </CardContent>
-      </Card>
+      </Card> */}
 
       <StatisticCharts
         monthlyRentalData={monthlyRentalData}

--- a/src/pages/admin/statistic/AdminStatisticSection.tsx
+++ b/src/pages/admin/statistic/AdminStatisticSection.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
-
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { CalendarIcon } from "lucide-react";
 import BizMonthlyCardStatistic from "./BizMonthlyCardStatistic";
 import BizStatisticTable from "./BizStatisticTable";
 import StatisticCharts from "./StatisticCharts";
 import MonthlyDriveCountChart from "./MonthlyDriveCountChart";
 
 import adminStatisticApiService from "@/libs/apis/adminStatisticApi";
-import { BizList, bizListMock, bizRatingDistribution, BizStatistic, bizStatisticMock, dailyActiveUsersData, GraphStats, graphStatsMock, HourlyDriveCounts, hourlyDriveCountsMock, MonthlyDriveCounts, monthlyDriveCountsMock, monthlyRentalData, vehicleTypeDistribution } from "@/constants/mocks/adminStaticsMockData";
-import DailyStatisticCharts from "./DailyStatisticCharts";
+import { BizList, bizListMock, BizStatistic, bizStatisticMock, GraphStats, graphStatsMock, HourlyDriveCounts, hourlyDriveCountsMock, MonthlyDriveCounts, monthlyDriveCountsMock} from "@/constants/mocks/adminStaticsMockData";
+import { Button } from "@/components/ui/button";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 
 function AdminStatisticSection() {
   
@@ -63,18 +63,36 @@ function AdminStatisticSection() {
   return (
     <div className="space-y-6 p-6">
       <div className="flex justify-between items-center">
-        <h1 className="text-3xl font-bold">업체별 통계 대시보드</h1>
+        <h1 className="text-3xl font-bold">업체별 통계</h1>
       </div>
-
-      <BizStatisticTable
-        data={bizList}
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm} 
-        selectedBiz={selectedBiz}
-        setSelectedBiz={setSelectedBiz}
-        selectedDate={selectedDate}
-        setSelectedDate={setSelectedDate} 
-      />
+        <BizStatisticTable
+          data={bizList}
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          selectedBiz={selectedBiz}
+          setSelectedBiz={setSelectedBiz}
+        />
+      <div className="flex justify-between items-center">
+        <h3 className="text-xl font-bold">{selectedBiz == '' ? '전체' : selectedBiz} 업체의 월별 통계</h3>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="w-[150px] justify-start text-left font-normal">
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {selectedDate ? format(selectedDate, "yyyy-MM-dd") : "날짜 선택"}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              onSelect={setSelectedDate}
+              locale={ko}
+              defaultMonth={selectedDate || undefined}
+              initialFocus
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
       <BizMonthlyCardStatistic summary={bizStatistic} formatSeconds={formatSeconds} />
       <MonthlyDriveCountChart 
         monthlyData={monthlyDriveCounts}
@@ -83,26 +101,8 @@ function AdminStatisticSection() {
         selectedDate={selectedDate}
       />
 
-      <h1 className="text-3xl font-bold">총 업체 통계</h1>
-      {/* <Card>
-        <CardHeader>
-          <CardTitle>전일 시간별 운행량</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="text-center text-sm text-gray-500">로딩 중...</div>
-          ) : (
-            <DailyStatisticCharts selectedDate={selectedDate} dailyData={bizList} />
-          )}
-        </CardContent>
-      </Card> */}
-
-      <StatisticCharts
-        // monthlyRentalData={monthlyRentalData}
-        // dailyActiveUsersData={dailyActiveUsersData}
-        // vehicleTypeDistribution={vehicleTypeDistribution}
-        // bizRatingDistribution={bizRatingDistribution}
-        graphStats={graphStats}
+      <h1 className="text-3xl font-bold">종합 통계</h1>
+      <StatisticCharts graphStats={graphStats}
       />
     </div>
   );

--- a/src/pages/admin/statistic/BizMonthlyCardStatistic.tsx
+++ b/src/pages/admin/statistic/BizMonthlyCardStatistic.tsx
@@ -1,0 +1,53 @@
+// components/BizMonthlyCardStatistic.tsx
+interface MonthlySummary {
+  totalDriveCount: number;
+  totalDrivingSeconds: number;
+  totalDrivingDistanceKm: number;
+}
+
+interface Props {
+  summary: MonthlySummary;
+  formatSeconds: (seconds: number) => string;
+}
+
+const BizMonthlyCardStatistic = ({ summary, formatSeconds }: Props) => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="bg-gradient-to-br from-purple-50 to-white rounded-xl border border-purple-100 shadow-sm hover:shadow-md transition-all duration-300">
+        <div className="p-5">
+          <h3 className="text-sm font-medium text-gray-500 mb-4">월 총 운행량</h3>
+          <div className="flex items-baseline">
+            <span className="text-3xl font-bold text-purple-600">{summary.totalDriveCount}</span>
+            <span className="ml-2 text-sm font-medium text-gray-500">회</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-gradient-to-br from-orange-50 to-white rounded-xl border border-orange-100 shadow-sm hover:shadow-md transition-all duration-300">
+        <div className="p-5">
+          <h3 className="text-sm font-medium text-gray-500 mb-4">월 총 운행 시간</h3>
+          <div className="flex items-baseline">
+            <span className="text-3xl font-bold text-orange-600">
+              {formatSeconds(summary.totalDrivingSeconds)}
+            </span>
+            <span className="ml-2 text-sm font-medium text-gray-500">시간</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-gradient-to-br from-cyan-50 to-white rounded-xl border border-cyan-100 shadow-sm hover:shadow-md transition-all duration-300">
+        <div className="p-5">
+          <h3 className="text-sm font-medium text-gray-500 mb-4">월 총 운행거리</h3>
+          <div className="flex items-baseline">
+            <span className="text-3xl font-bold text-cyan-600">
+              {summary.totalDrivingDistanceKm.toFixed(0)}
+            </span>
+            <span className="ml-2 text-sm font-medium text-gray-500">km</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BizMonthlyCardStatistic;

--- a/src/pages/admin/statistic/BizMonthlyCardStatistic.tsx
+++ b/src/pages/admin/statistic/BizMonthlyCardStatistic.tsx
@@ -1,12 +1,7 @@
-// components/BizMonthlyCardStatistic.tsx
-interface MonthlySummary {
-  totalDriveCount: number;
-  totalDrivingSeconds: number;
-  totalDrivingDistanceKm: number;
-}
+import { BizStatistic } from "@/constants/mocks/adminStaticsMockData";
 
 interface Props {
-  summary: MonthlySummary;
+  summary: BizStatistic;
   formatSeconds: (seconds: number) => string;
 }
 
@@ -17,7 +12,7 @@ const BizMonthlyCardStatistic = ({ summary, formatSeconds }: Props) => {
         <div className="p-5">
           <h3 className="text-sm font-medium text-gray-500 mb-4">월 총 운행량</h3>
           <div className="flex items-baseline">
-            <span className="text-3xl font-bold text-purple-600">{summary.totalDriveCount}</span>
+            <span className="text-3xl font-bold text-purple-600">{summary.dailyDriveCount}</span>
             <span className="ml-2 text-sm font-medium text-gray-500">회</span>
           </div>
         </div>
@@ -28,7 +23,7 @@ const BizMonthlyCardStatistic = ({ summary, formatSeconds }: Props) => {
           <h3 className="text-sm font-medium text-gray-500 mb-4">월 총 운행 시간</h3>
           <div className="flex items-baseline">
             <span className="text-3xl font-bold text-orange-600">
-              {formatSeconds(summary.totalDrivingSeconds)}
+              {formatSeconds(summary.dailyDriveSec)}
             </span>
             <span className="ml-2 text-sm font-medium text-gray-500">시간</span>
           </div>
@@ -40,7 +35,7 @@ const BizMonthlyCardStatistic = ({ summary, formatSeconds }: Props) => {
           <h3 className="text-sm font-medium text-gray-500 mb-4">월 총 운행거리</h3>
           <div className="flex items-baseline">
             <span className="text-3xl font-bold text-cyan-600">
-              {summary.totalDrivingDistanceKm.toFixed(0)}
+              {(summary.dailyDriveDistance / 1000).toFixed(2)}
             </span>
             <span className="ml-2 text-sm font-medium text-gray-500">km</span>
           </div>

--- a/src/pages/admin/statistic/BizStatisticTable.tsx
+++ b/src/pages/admin/statistic/BizStatisticTable.tsx
@@ -2,33 +2,36 @@ import { useState } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { BizStatistic } from "@/constants/mocks/adminStaticsMockData";
+import { BizList, BizStatistic } from "@/constants/mocks/adminStaticsMockData";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { CalendarIcon } from "lucide-react";
 
 import { format } from "date-fns";
-import { ko } from "date-fns/locale";
+import { is, ko } from "date-fns/locale";
 
 interface BizStatisticTableProps {
-  data: BizStatistic[];
+  data: BizList[];
+  searchTerm: string;
+  setSearchTerm: (searchTerm: string) => void;
+  selectedBiz: string;
   setSelectedBiz: (selectedBiz: string) => void;
+  selectedDate: Date | undefined;
+  setSelectedDate: (selectedDate: Date | undefined) => void;
 }
 
-function BizStatisticTable({ data, setSelectedBiz }: BizStatisticTableProps) {
-  const [searchTerm, setSearchTerm] = useState("");
+function BizStatisticTable({ data, searchTerm, setSearchTerm, selectedBiz, setSelectedBiz, selectedDate, setSelectedDate }: BizStatisticTableProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
 
   const filteredData = data.filter((item) =>
-    item.name.toLowerCase().includes(searchTerm.toLowerCase())
+    item.bizName.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   const totalPages = Math.ceil(filteredData.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const currentData = filteredData.slice(startIndex, endIndex);
-  const [date, setDate] = useState<Date | undefined>();
 
   return (
     <div className="space-y-4">
@@ -46,16 +49,16 @@ function BizStatisticTable({ data, setSelectedBiz }: BizStatisticTableProps) {
           <PopoverTrigger asChild>
             <Button variant="outline" className="w-[150px] justify-start text-left font-normal">
               <CalendarIcon className="mr-2 h-4 w-4" />
-              {date ? format(date, "yyyy-MM-dd") : "날짜 선택"}
+              {selectedDate ? format(selectedDate, "yyyy-MM-dd") : "날짜 선택"}
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-0">
             <Calendar
               mode="single"
-              selected={date}
-              onSelect={setDate}
+              selected={selectedDate}
+              onSelect={setSelectedDate}
               locale={ko}
-              defaultMonth={date || undefined}
+              defaultMonth={selectedDate || undefined}
               initialFocus
             />
           </PopoverContent>
@@ -69,36 +72,47 @@ function BizStatisticTable({ data, setSelectedBiz }: BizStatisticTableProps) {
               <th className="p-4 text-left font-medium">업체명</th>
               <th className="p-4 text-left font-medium">전체 차량</th>
               <th className="p-4 text-left font-medium">운행 중</th>
-              <th className="p-4 text-left font-medium">총 렌트</th>
-              <th className="p-4 text-left font-medium">총 운행거리</th>
-              <th className="p-4 text-left font-medium">평균 평점</th>
+              <th className="p-4 text-left font-medium">오류</th>
               <th className="p-4 text-left font-medium">상세</th>
             </tr>
           </thead>
           <tbody>
-            {currentData.map((item) => (
-              <tr key={item.id} className="border-b">
-                <td
-                  className="p-4"
+            {currentData.map((item, idx) => {
+              let isSelected = false;
+              if(idx == 0 && selectedBiz == '') isSelected = true;
+              else isSelected = selectedBiz === item.bizName;
+
+              return (
+                <tr
+                  key={idx}
+                  className={`
+                    border-b
+                    hover:cursor-pointer
+                    hover:bg-gray-100
+                    ${isSelected ? "bg-gray-100" : ""}
+                  `}
                   onClick={() => {
-                    //승택님 여기서부터 하시면 됩니다..
-                    // setSelectedBiz(item.bizName);
-                  }}
+                      if(idx === 0) setSelectedBiz('');
+                      else setSelectedBiz(item.bizName);
+                    }
+                  }
                 >
-                  {item.name}
-                </td>
-                <td className="p-4">{item.totalVehicles}</td>
-                <td className="p-4">{item.activeVehicles}</td>
-                <td className="p-4">{item.totalRentals}</td>
-                <td className="p-4">{item.totalDistance}</td>
-                <td className="p-4">{item.averageRating}/5.0</td>
-                <td className="p-4">
-                  <Button variant="outline" size="sm">
-                    보기
-                  </Button>
-                </td>
-              </tr>
-            ))}
+                  <td className="p-4">{item.bizName}</td>
+                  <td className="p-4">{item.totalCarCount}</td>
+                  <td className="p-4">{item.drivingCarCount}</td>
+                  <td className="p-4">{item.skipCount}</td>
+                  <td className="p-4">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setSelectedBiz(item.bizName)}
+                    >
+                      보기
+                    </Button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/src/pages/admin/statistic/BizStatisticTable.tsx
+++ b/src/pages/admin/statistic/BizStatisticTable.tsx
@@ -2,13 +2,7 @@ import { useState } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { BizList, BizStatistic } from "@/constants/mocks/adminStaticsMockData";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Calendar } from "@/components/ui/calendar";
-import { CalendarIcon } from "lucide-react";
-
-import { format } from "date-fns";
-import { is, ko } from "date-fns/locale";
+import { BizList } from "@/constants/mocks/adminStaticsMockData";
 
 interface BizStatisticTableProps {
   data: BizList[];
@@ -16,13 +10,11 @@ interface BizStatisticTableProps {
   setSearchTerm: (searchTerm: string) => void;
   selectedBiz: string;
   setSelectedBiz: (selectedBiz: string) => void;
-  selectedDate: Date | undefined;
-  setSelectedDate: (selectedDate: Date | undefined) => void;
 }
 
-function BizStatisticTable({ data, searchTerm, setSearchTerm, selectedBiz, setSelectedBiz, selectedDate, setSelectedDate }: BizStatisticTableProps) {
+function BizStatisticTable({ data, searchTerm, setSearchTerm, selectedBiz, setSelectedBiz}: BizStatisticTableProps) {
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 5;
+  const itemsPerPage = 3;
 
   const filteredData = data.filter((item) =>
     item.bizName.toLowerCase().includes(searchTerm.toLowerCase())
@@ -45,7 +37,7 @@ function BizStatisticTable({ data, searchTerm, setSearchTerm, selectedBiz, setSe
             onChange={(e) => setSearchTerm(e.target.value)}
           />
         </div>
-        <Popover>
+        {/* <Popover>
           <PopoverTrigger asChild>
             <Button variant="outline" className="w-[150px] justify-start text-left font-normal">
               <CalendarIcon className="mr-2 h-4 w-4" />
@@ -62,18 +54,18 @@ function BizStatisticTable({ data, searchTerm, setSearchTerm, selectedBiz, setSe
               initialFocus
             />
           </PopoverContent>
-        </Popover>
+        </Popover> */}
       </div>
 
       <div className="rounded-md border">
         <table className="w-full">
           <thead>
             <tr className="border-b bg-muted/50">
-              <th className="p-4 text-left font-medium">업체명</th>
-              <th className="p-4 text-left font-medium">전체 차량</th>
-              <th className="p-4 text-left font-medium">운행 중</th>
-              <th className="p-4 text-left font-medium">오류</th>
-              <th className="p-4 text-left font-medium">상세</th>
+              <th className="px-4 py-2 text-left font-medium">업체명</th>
+              <th className="px-4 py-2 text-left font-medium">전체 차량</th>
+              <th className="px-4 py-2 text-left font-medium">현재 운행 중</th>
+              <th className="px-4 py-2 text-left font-medium">오류</th>
+              <th className="px-4 py-2 text-left font-medium">상세</th>
             </tr>
           </thead>
           <tbody>
@@ -92,16 +84,16 @@ function BizStatisticTable({ data, searchTerm, setSearchTerm, selectedBiz, setSe
                     ${isSelected ? "bg-gray-100" : ""}
                   `}
                   onClick={() => {
-                      if(idx === 0) setSelectedBiz('');
+                      if(idx === 0 && item.bizName === '전체') setSelectedBiz('');
                       else setSelectedBiz(item.bizName);
                     }
                   }
                 >
-                  <td className="p-4">{item.bizName}</td>
-                  <td className="p-4">{item.totalCarCount}</td>
-                  <td className="p-4">{item.drivingCarCount}</td>
-                  <td className="p-4">{item.skipCount}</td>
-                  <td className="p-4">
+                  <td className="px-4 py-2">{item.bizName}</td>
+                  <td className="px-4 py-2">{item.totalCarCount}</td>
+                  <td className="px-4 py-2">{item.drivingCarCount}</td>
+                  <td className="px-4 py-2">{item.skipCount}</td>
+                  <td className="px-4 py-2">
                     <Button
                       variant="outline"
                       size="sm"

--- a/src/pages/admin/statistic/BizStatisticTable.tsx
+++ b/src/pages/admin/statistic/BizStatisticTable.tsx
@@ -3,12 +3,19 @@ import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { BizStatistic } from "@/constants/mocks/adminStaticsMockData";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { CalendarIcon } from "lucide-react";
+
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 
 interface BizStatisticTableProps {
   data: BizStatistic[];
+  setSelectedBiz: (selectedBiz: string) => void;
 }
 
-function BizStatisticTable({ data }: BizStatisticTableProps) {
+function BizStatisticTable({ data, setSelectedBiz }: BizStatisticTableProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
@@ -21,6 +28,7 @@ function BizStatisticTable({ data }: BizStatisticTableProps) {
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const currentData = filteredData.slice(startIndex, endIndex);
+  const [date, setDate] = useState<Date | undefined>();
 
   return (
     <div className="space-y-4">
@@ -34,6 +42,24 @@ function BizStatisticTable({ data }: BizStatisticTableProps) {
             onChange={(e) => setSearchTerm(e.target.value)}
           />
         </div>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="w-[150px] justify-start text-left font-normal">
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {date ? format(date, "yyyy-MM-dd") : "날짜 선택"}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={date}
+              onSelect={setDate}
+              locale={ko}
+              defaultMonth={date || undefined}
+              initialFocus
+            />
+          </PopoverContent>
+        </Popover>
       </div>
 
       <div className="rounded-md border">
@@ -52,7 +78,15 @@ function BizStatisticTable({ data }: BizStatisticTableProps) {
           <tbody>
             {currentData.map((item) => (
               <tr key={item.id} className="border-b">
-                <td className="p-4">{item.name}</td>
+                <td
+                  className="p-4"
+                  onClick={() => {
+                    //승택님 여기서부터 하시면 됩니다..
+                    // setSelectedBiz(item.bizName);
+                  }}
+                >
+                  {item.name}
+                </td>
                 <td className="p-4">{item.totalVehicles}</td>
                 <td className="p-4">{item.activeVehicles}</td>
                 <td className="p-4">{item.totalRentals}</td>
@@ -94,6 +128,6 @@ function BizStatisticTable({ data }: BizStatisticTableProps) {
       </div>
     </div>
   );
-} 
+}
 
 export default BizStatisticTable;

--- a/src/pages/admin/statistic/DailyStatisticCharts.tsx
+++ b/src/pages/admin/statistic/DailyStatisticCharts.tsx
@@ -1,0 +1,123 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import { DailyStatisticResponse, HourlyStats } from "@/libs/apis/statisticApi";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+interface DailyChartsProps {
+  selectedDate: Date;
+  dailyData: DailyStatisticResponse | null;
+  compareDate?: Date | null;
+  compareData?: DailyStatisticResponse | null;
+  isLoadingCompare?: boolean;
+}
+
+function DailyStatisticCharts({
+  selectedDate,
+  dailyData,
+  compareDate,
+  compareData,
+  isLoadingCompare = false,
+}: DailyChartsProps) {
+  const getChartData = () => {
+    const labels = Array.from({ length: 24 }, (_, i) => `${i}시`);
+    const datasets = [];
+
+    if (dailyData) {
+      const hourlyData = Array(24).fill(0);
+      dailyData.hourlyStats.forEach((stat: HourlyStats) => {
+        hourlyData[stat.hour] = stat.driveCount;
+      });
+
+      datasets.push({
+        label: format(selectedDate, "M월 d일", { locale: ko }),
+        data: hourlyData,
+        fill: false,
+        borderColor: "rgb(75, 192, 192)",
+        tension: 0.4,
+        pointRadius: 4,
+        pointHoverRadius: 6,
+      });
+    }
+
+    if (compareDate) {
+      const hourlyData = Array(24).fill(0);
+
+      if (compareData) {
+        compareData.hourlyStats.forEach((stat: HourlyStats) => {
+          hourlyData[stat.hour] = stat.driveCount;
+        });
+      }
+
+      datasets.push({
+        label: format(compareDate, "M월 d일", { locale: ko }),
+        data: compareData ? hourlyData : Array(24).fill(0),
+        fill: false,
+        borderColor: "rgb(255, 99, 132)",
+        tension: 0.4,
+        pointRadius: 4,
+        pointHoverRadius: 6,
+      });
+    }
+
+    return {
+      labels,
+      datasets,
+    };
+  };
+
+  return (
+    <div className="h-[300px]">
+      {isLoadingCompare && <p className="text-sm text-gray-500 mb-2">비교 데이터 로딩 중...</p>}
+      <Line
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              position: "top" as const,
+            },
+            tooltip: {
+              mode: "index",
+              intersect: false,
+            },
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              title: {
+                display: true,
+                text: "운행 차량 수",
+              },
+            },
+            x: {
+              title: {
+                display: true,
+                text: "시간",
+              },
+            },
+          },
+          interaction: {
+            mode: "nearest",
+            axis: "x",
+            intersect: false,
+          },
+        }}
+        data={getChartData()}
+      />
+    </div>
+  );
+}
+
+export default DailyStatisticCharts;

--- a/src/pages/admin/statistic/MonthlyDriveCountChart.tsx
+++ b/src/pages/admin/statistic/MonthlyDriveCountChart.tsx
@@ -1,82 +1,130 @@
 // components/MonthlyDriveCountChart.tsx
+import { useState, useEffect } from "react";
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
   PointElement,
   LineElement,
-  Title,
+  Title as TitlePlugin,
   Tooltip,
   Legend,
 } from "chart.js";
 import { Line } from "react-chartjs-2";
 import { ChartOptions } from "chart.js";
-import { formatDate } from "date-fns";
-import { MonthlyDriveCounts } from "@/constants/mocks/adminStaticsMockData";
+import { MonthlyDriveCounts, HourlyDriveCounts } from "@/constants/mocks/adminStaticsMockData";
+import adminStatisticApiService from "@/libs/apis/adminStatisticApi";
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  TitlePlugin,
+  Tooltip,
+  Legend
+);
 
 interface MonthlyDriveCountChartProps {
-  title?: string;
-  data: MonthlyDriveCounts[];
+  monthlyData: MonthlyDriveCounts[];
+  hourlyData: HourlyDriveCounts[];
+  selectedBiz: string;
+  selectedDate: Date | undefined;
 }
 
-const chartOptions: ChartOptions<"line"> = {
-  responsive: true,
-  maintainAspectRatio: false,
-  plugins: {
-    legend: { display: false },
-    tooltip: {
-      mode: "index",
+export default function MonthlyDriveCountChart({ monthlyData, hourlyData, selectedBiz, selectedDate }: MonthlyDriveCountChartProps) {
+  // 모드 토글: false=월별, true=시간별
+  const [isHourly, setIsHourly] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // 버튼 클릭 핸들러
+  const handleToggle = async () => {
+    setIsHourly(prev => !prev);
+  };
+
+  // chart.js 옵션 (공통)
+  const chartOptions: ChartOptions<"line"> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      title: {
+        display: true,
+        text: isHourly ? "시간별 운행량" : "월별 운행량",
+      },
+      tooltip: {
+        mode: "index",
+        intersect: false,
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        title: {
+          display: true,
+          text: "운행 횟수",
+        },
+      },
+      x: {
+        title: {
+          display: true,
+          text: isHourly ? "시간(시)" : "월",
+        },
+      },
+    },
+    interaction: {
+      mode: "nearest",
+      axis: "x",
       intersect: false,
     },
-  },
-  scales: {
-    y: {
-      beginAtZero: true,
-      ticks: {
-        stepSize: 1,
-      },
-      title: {
-        display: true,
-        text: "운행 횟수",
-      },
-    },
-    x: {
-      title: {
-        display: true,
-        text: "월",
-      },
-    },
-  },
-  interaction: {
-    mode: "nearest",
-    axis: "x",
-    intersect: false,
-  },
-};
-
-function MonthlyDriveCountChart({ title = "월별 운행량", data }: MonthlyDriveCountChartProps) {
-  const chartData = {
-    labels: data.map(item => item.year + '-' + item.month),
-    datasets: [
-      {
-        label: "운행량",
-        data: data.map(item => item.driveCount),
-        borderColor: "rgb(75, 192, 192)",
-        fill: false,
-        tension: 0.3,
-        pointRadius: 4,
-        pointHoverRadius: 6,
-      },
-    ],
   };
+
+  // chartData 생성
+  const chartData = isHourly
+    ? {
+        labels: hourlyData.map(h => `${h.hour}시`),
+        datasets: [
+          {
+            label: "운행량",
+            data: hourlyData.map(h => h.driveCount),
+            borderColor: "rgb(75, 192, 192)",
+            fill: false,
+            tension: 0.3,
+            pointRadius: 4,
+            pointHoverRadius: 6,
+          },
+        ],
+      }
+    : {
+        labels: monthlyData.map(m => `${m.year}-${String(m.month).padStart(2, "0")}`),
+        datasets: [
+          {
+            label: "운행량",
+            data: monthlyData.map(m => m.driveCount),
+            borderColor: "rgb(75, 192, 192)",
+            fill: false,
+            tension: 0.3,
+            pointRadius: 4,
+            pointHoverRadius: 6,
+          },
+        ],
+      };
 
   return (
     <div className="bg-white rounded-xl border border-gray-100 shadow-sm hover:shadow-md transition-all duration-300">
-      <div className="p-5 border-b border-gray-50">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <div className="flex items-center justify-between p-5 border-b border-gray-50">
+        <h3 className="text-lg font-semibold text-gray-900">
+          {chartOptions.plugins?.title?.text}
+        </h3>
+        <button
+          onClick={handleToggle}
+          disabled={loading}
+          className="text-sm text-blue-600 hover:underline disabled:text-gray-400"
+        >
+          {isHourly ? "월별 운행량 보기" : "시간별 운행량 보기"}
+        </button>
       </div>
+
       <div className="p-5">
         <div className="h-[300px]">
           <Line data={chartData} options={chartOptions} />
@@ -85,5 +133,3 @@ function MonthlyDriveCountChart({ title = "월별 운행량", data }: MonthlyDri
     </div>
   );
 }
-
-export default MonthlyDriveCountChart;

--- a/src/pages/admin/statistic/MonthlyDriveCountChart.tsx
+++ b/src/pages/admin/statistic/MonthlyDriveCountChart.tsx
@@ -1,0 +1,87 @@
+// components/MonthlyDriveCountChart.tsx
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import { ChartOptions } from "chart.js";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+interface MonthlyDriveCountChartProps {
+  title?: string;
+  data: { labels: string[]; values: number[] };
+}
+
+const chartOptions: ChartOptions<"line"> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      mode: "index",
+      intersect: false,
+    },
+  },
+  scales: {
+    y: {
+      beginAtZero: true,
+      ticks: {
+        stepSize: 1,
+      },
+      title: {
+        display: true,
+        text: "운행 횟수",
+      },
+    },
+    x: {
+      title: {
+        display: true,
+        text: "월",
+      },
+    },
+  },
+  interaction: {
+    mode: "nearest",
+    axis: "x",
+    intersect: false,
+  },
+};
+
+function MonthlyDriveCountChart({ title = "월별 운행량", data }: MonthlyDriveCountChartProps) {
+  const chartData = {
+    labels: data.labels,
+    datasets: [
+      {
+        label: "운행량",
+        data: data.values,
+        borderColor: "rgb(75, 192, 192)",
+        fill: false,
+        tension: 0.3,
+        pointRadius: 4,
+        pointHoverRadius: 6,
+      },
+    ],
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-100 shadow-sm hover:shadow-md transition-all duration-300">
+      <div className="p-5 border-b border-gray-50">
+        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      </div>
+      <div className="p-5">
+        <div className="h-[300px]">
+          <Line data={chartData} options={chartOptions} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MonthlyDriveCountChart;

--- a/src/pages/admin/statistic/MonthlyDriveCountChart.tsx
+++ b/src/pages/admin/statistic/MonthlyDriveCountChart.tsx
@@ -11,12 +11,14 @@ import {
 } from "chart.js";
 import { Line } from "react-chartjs-2";
 import { ChartOptions } from "chart.js";
+import { formatDate } from "date-fns";
+import { MonthlyDriveCounts } from "@/constants/mocks/adminStaticsMockData";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 interface MonthlyDriveCountChartProps {
   title?: string;
-  data: { labels: string[]; values: number[] };
+  data: MonthlyDriveCounts[];
 }
 
 const chartOptions: ChartOptions<"line"> = {
@@ -56,11 +58,11 @@ const chartOptions: ChartOptions<"line"> = {
 
 function MonthlyDriveCountChart({ title = "월별 운행량", data }: MonthlyDriveCountChartProps) {
   const chartData = {
-    labels: data.labels,
+    labels: data.map(item => item.year + '-' + item.month),
     datasets: [
       {
         label: "운행량",
-        data: data.values,
+        data: data.map(item => item.driveCount),
         borderColor: "rgb(75, 192, 192)",
         fill: false,
         tension: 0.3,

--- a/src/pages/admin/statistic/StatisticCharts.tsx
+++ b/src/pages/admin/statistic/StatisticCharts.tsx
@@ -11,7 +11,7 @@ import {
   Legend,
 } from "chart.js";
 import { Line, Bar } from "react-chartjs-2";
-import { TimeSeriesData } from "@/constants/mocks/adminStaticsMockData";
+import { GraphStats, TimeSeriesData } from "@/constants/mocks/adminStaticsMockData";
 
 ChartJS.register(
   CategoryScale,
@@ -25,18 +25,15 @@ ChartJS.register(
 );
 
 interface StatisticChartsProps {
-  monthlyRentalData: TimeSeriesData[];
-  dailyActiveUsersData: TimeSeriesData[];
-  vehicleTypeDistribution: { type: string; count: number }[];
-  bizRatingDistribution: { rating: string; count: number }[];
+  // monthlyRentalData: TimeSeriesData[];
+  // dailyActiveUsersData: TimeSeriesData[];
+  // vehicleTypeDistribution: { type: string; count: number }[];
+  // bizRatingDistribution: { rating: string; count: number }[];
+  graphStats: GraphStats;
 }
 
-function StatisticCharts({
-  monthlyRentalData,
-  dailyActiveUsersData,
-  vehicleTypeDistribution,
-  bizRatingDistribution,
-}: StatisticChartsProps) {
+function StatisticCharts({graphStats}: StatisticChartsProps) {
+
   const monthlyRentalOptions = {
     responsive: true,
     plugins: {
@@ -90,11 +87,11 @@ function StatisticCharts({
   };
 
   const monthlyRentalChartData = {
-    labels: monthlyRentalData.map((item) => item.date),
+    labels: graphStats.carCountWithBizName.map((item) => item.bizName),
     datasets: [
       {
         label: "운행 횟수",
-        data: monthlyRentalData.map((item) => item.value),
+        data: graphStats.carCountWithBizName.map((item) => item.carCount),
         borderColor: "rgb(136, 132, 216)",
         backgroundColor: "rgba(136, 132, 216, 0.5)",
       },
@@ -102,11 +99,11 @@ function StatisticCharts({
   };
 
   const dailyActiveUsersChartData = {
-    labels: dailyActiveUsersData.map((item) => item.date),
+    labels: graphStats.operationRateWithBizName.map((item) => item.bizName),
     datasets: [
       {
         label: "차량 수",
-        data: dailyActiveUsersData.map((item) => item.value),
+        data: graphStats.operationRateWithBizName.map((item) => item.rate),
         borderColor: "rgb(130, 202, 157)",
         backgroundColor: "rgba(130, 202, 157, 0.5)",
       },
@@ -114,26 +111,26 @@ function StatisticCharts({
   };
 
   const vehicleTypeChartData = {
-    labels: vehicleTypeDistribution.map((item) => item.type),
+    labels: graphStats.nonOperatedCarWithBizName.map((item) => item.bizName),
     datasets: [
       {
         label: "운행 수",
-        data: vehicleTypeDistribution.map((item) => item.count),
+        data: graphStats.nonOperatedCarWithBizName.map((item) => item.nonOperatedCarCount),
         backgroundColor: "rgba(136, 132, 216, 0.5)",
       },
     ],
   };
 
-  const bizRatingChartData = {
-    labels: bizRatingDistribution.map((item) => item.rating),
-    datasets: [
-      {
-        label: "운행 수",
-        data: bizRatingDistribution.map((item) => item.count),
-        backgroundColor: "rgba(130, 202, 157, 0.5)",
-      },
-    ],
-  };
+  // const bizRatingChartData = {
+  //   labels: bizRatingDistribution.map((item) => item.rating),
+  //   datasets: [
+  //     {
+  //       label: "운행 수",
+  //       data: bizRatingDistribution.map((item) => item.count),
+  //       backgroundColor: "rgba(130, 202, 157, 0.5)",
+  //     },
+  //   ],
+  // };
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
@@ -155,11 +152,11 @@ function StatisticCharts({
         </CardContent>
       </Card>
 
-      <Card>
+      {/* <Card>
         <CardContent className="pt-6">
           <Bar options={bizRatingOptions} data={bizRatingChartData} />
         </CardContent>
-      </Card>
+      </Card> */}
     </div>
   );
 }

--- a/src/pages/admin/statistic/StatisticCharts.tsx
+++ b/src/pages/admin/statistic/StatisticCharts.tsx
@@ -45,7 +45,7 @@ function StatisticCharts({
       },
       title: {
         display: true,
-        text: "월별 렌트 현황",
+        text: "당월 평균 운행률",
       },
     },
   };
@@ -58,7 +58,7 @@ function StatisticCharts({
       },
       title: {
         display: true,
-        text: "일일 활성 사용자",
+        text: "당월 미운행 차량수",
       },
     },
   };
@@ -71,7 +71,7 @@ function StatisticCharts({
       },
       title: {
         display: true,
-        text: "차종별 분포",
+        text: "당월 총 운행량",
       },
     },
   };
@@ -84,7 +84,7 @@ function StatisticCharts({
       },
       title: {
         display: true,
-        text: "업체 평점 분포",
+        text: "일별 운행수",
       },
     },
   };
@@ -93,7 +93,7 @@ function StatisticCharts({
     labels: monthlyRentalData.map((item) => item.date),
     datasets: [
       {
-        label: "렌트 수",
+        label: "운행 횟수",
         data: monthlyRentalData.map((item) => item.value),
         borderColor: "rgb(136, 132, 216)",
         backgroundColor: "rgba(136, 132, 216, 0.5)",
@@ -105,7 +105,7 @@ function StatisticCharts({
     labels: dailyActiveUsersData.map((item) => item.date),
     datasets: [
       {
-        label: "활성 사용자 수",
+        label: "차량 수",
         data: dailyActiveUsersData.map((item) => item.value),
         borderColor: "rgb(130, 202, 157)",
         backgroundColor: "rgba(130, 202, 157, 0.5)",
@@ -117,7 +117,7 @@ function StatisticCharts({
     labels: vehicleTypeDistribution.map((item) => item.type),
     datasets: [
       {
-        label: "차량 수",
+        label: "운행 수",
         data: vehicleTypeDistribution.map((item) => item.count),
         backgroundColor: "rgba(136, 132, 216, 0.5)",
       },
@@ -128,7 +128,7 @@ function StatisticCharts({
     labels: bizRatingDistribution.map((item) => item.rating),
     datasets: [
       {
-        label: "업체 수",
+        label: "운행 수",
         data: bizRatingDistribution.map((item) => item.count),
         backgroundColor: "rgba(130, 202, 157, 0.5)",
       },
@@ -162,6 +162,6 @@ function StatisticCharts({
       </Card>
     </div>
   );
-} 
+}
 
 export default StatisticCharts;

--- a/src/pages/admin/statistic/StatisticCharts.tsx
+++ b/src/pages/admin/statistic/StatisticCharts.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
-import { Line, Bar } from "react-chartjs-2";
+import { Line, Bar, Doughnut } from "react-chartjs-2";
 import { GraphStats, TimeSeriesData } from "@/constants/mocks/adminStaticsMockData";
 
 ChartJS.register(
@@ -25,16 +25,42 @@ ChartJS.register(
 );
 
 interface StatisticChartsProps {
-  // monthlyRentalData: TimeSeriesData[];
-  // dailyActiveUsersData: TimeSeriesData[];
-  // vehicleTypeDistribution: { type: string; count: number }[];
-  // bizRatingDistribution: { rating: string; count: number }[];
   graphStats: GraphStats;
 }
 
 function StatisticCharts({graphStats}: StatisticChartsProps) {
 
-  const monthlyRentalOptions = {
+  const carCountOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    aspectRatio: 1,
+    plugins: {
+      legend: {
+        position: "top" as const,
+      },
+      title: {
+        display: true,
+        text: "전체 차량 수",
+      },
+    },
+  };
+
+  const carTypeOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    aspectRatio: 1,
+    plugins: {
+      legend: {
+        position: "top" as const,
+      },
+      title: {
+        display: true,
+        text: "전체 차종 분포",
+      },
+    },
+  };
+
+  const operationRateOptions = {
     responsive: true,
     plugins: {
       legend: {
@@ -42,12 +68,12 @@ function StatisticCharts({graphStats}: StatisticChartsProps) {
       },
       title: {
         display: true,
-        text: "당월 평균 운행률",
+        text: "월 가동률 순위",
       },
     },
   };
 
-  const dailyActiveUsersOptions = {
+  const nonOperatedCarOptions = {
     responsive: true,
     plugins: {
       legend: {
@@ -55,54 +81,52 @@ function StatisticCharts({graphStats}: StatisticChartsProps) {
       },
       title: {
         display: true,
-        text: "당월 미운행 차량수",
+        text: "월 미운행 차량 수",
       },
     },
   };
 
-  const vehicleTypeOptions = {
-    responsive: true,
-    plugins: {
-      legend: {
-        position: "top" as const,
-      },
-      title: {
-        display: true,
-        text: "당월 총 운행량",
-      },
-    },
-  };
-
-  const bizRatingOptions = {
-    responsive: true,
-    plugins: {
-      legend: {
-        position: "top" as const,
-      },
-      title: {
-        display: true,
-        text: "일별 운행수",
-      },
-    },
-  };
-
-  const monthlyRentalChartData = {
+  const carCountChartData = {
     labels: graphStats.carCountWithBizName.map((item) => item.bizName),
     datasets: [
       {
-        label: "운행 횟수",
+        label: "차량 수",
         data: graphStats.carCountWithBizName.map((item) => item.carCount),
-        borderColor: "rgb(136, 132, 216)",
-        backgroundColor: "rgba(136, 132, 216, 0.5)",
+        backgroundColor: [
+          "#E57373", // 소프트 레드
+          "#FFB74D", // 머스터드 오렌지
+          "#FFF176", // 라이트 옐로우
+          "#AED581", // 소프트 그린
+          "#64B5F6", // 스카이 블루
+          "#BA68C8", // 라벤더 퍼플
+        ],
       },
     ],
   };
 
-  const dailyActiveUsersChartData = {
+  const carTypeChartData = {
+    labels: graphStats.carTypeCounts.map((item) => item.carType),
+    datasets: [
+      {
+        label: "",
+        data: graphStats.carTypeCounts.map((item) => item.carTypeCount),
+        backgroundColor: [
+          "#E57373", // 소프트 레드
+          "#FFB74D", // 머스터드 오렌지
+          "#FFF176", // 라이트 옐로우
+          "#AED581", // 소프트 그린
+          "#64B5F6", // 스카이 블루
+          "#BA68C8", // 라벤더 퍼플
+        ],
+      },
+    ],
+  };
+
+  const operationRateChartData = {
     labels: graphStats.operationRateWithBizName.map((item) => item.bizName),
     datasets: [
       {
-        label: "차량 수",
+        label: "가동률",
         data: graphStats.operationRateWithBizName.map((item) => item.rate),
         borderColor: "rgb(130, 202, 157)",
         backgroundColor: "rgba(130, 202, 157, 0.5)",
@@ -110,53 +134,46 @@ function StatisticCharts({graphStats}: StatisticChartsProps) {
     ],
   };
 
-  const vehicleTypeChartData = {
+  const nonOperatedCarChartData = {
     labels: graphStats.nonOperatedCarWithBizName.map((item) => item.bizName),
     datasets: [
       {
-        label: "운행 수",
+        label: "차량 수",
         data: graphStats.nonOperatedCarWithBizName.map((item) => item.nonOperatedCarCount),
         backgroundColor: "rgba(136, 132, 216, 0.5)",
       },
     ],
   };
 
-  // const bizRatingChartData = {
-  //   labels: bizRatingDistribution.map((item) => item.rating),
-  //   datasets: [
-  //     {
-  //       label: "운행 수",
-  //       data: bizRatingDistribution.map((item) => item.count),
-  //       backgroundColor: "rgba(130, 202, 157, 0.5)",
-  //     },
-  //   ],
-  // };
-
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <Card>
-        <CardContent className="pt-6">
-          <Line options={monthlyRentalOptions} data={monthlyRentalChartData} />
+        <CardContent className="pt-6 flex justify-center items-center">
+          <div className="w-[280px] h-[280px]">
+            <Doughnut options={carCountOptions} data={carCountChartData} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6 flex justify-center items-center">
+          <div className="w-[280px] h-[280px]">
+            <Doughnut options={carTypeOptions} data={carTypeChartData} />
+          </div>
         </CardContent>
       </Card>
 
       <Card>
         <CardContent className="pt-6">
-          <Line options={dailyActiveUsersOptions} data={dailyActiveUsersChartData} />
+          <Bar options={operationRateOptions} data={operationRateChartData} />
         </CardContent>
       </Card>
 
       <Card>
         <CardContent className="pt-6">
-          <Bar options={vehicleTypeOptions} data={vehicleTypeChartData} />
+          <Bar options={nonOperatedCarOptions} data={nonOperatedCarChartData} />
         </CardContent>
       </Card>
-
-      {/* <Card>
-        <CardContent className="pt-6">
-          <Bar options={bizRatingOptions} data={bizRatingChartData} />
-        </CardContent>
-      </Card> */}
     </div>
   );
 }

--- a/src/pages/dashboard/components/MonthlyStats.tsx
+++ b/src/pages/dashboard/components/MonthlyStats.tsx
@@ -20,35 +20,35 @@ interface MonthlyStatsProps {
 }
 
 function MonthlyStats({ monthlyData }: MonthlyStatsProps) {
-  const chartData = {
-    labels: monthlyData?.dailyDriveCount.map((_, index) => `${index + 1}일`),
-    datasets: [
-      {
-        label: "일별 운행 건수",
-        data: monthlyData?.dailyDriveCount.map((data) => data),
-        borderColor: "rgb(59, 130, 246)",
-        backgroundColor: "rgba(59, 130, 246, 0.5)",
-        tension: 0.4,
-      },
-    ],
-  };
+  // const chartData = {
+  //   labels: monthlyData?.dailyDriveCount.map((_, index) => `${index + 1}일`),
+  //   datasets: [
+  //     {
+  //       label: "일별 운행 건수",
+  //       data: monthlyData?.dailyDriveCount.map((data) => data),
+  //       borderColor: "rgb(59, 130, 246)",
+  //       backgroundColor: "rgba(59, 130, 246, 0.5)",
+  //       tension: 0.4,
+  //     },
+  //   ],
+  // };
 
-  const chartOptions = {
-    responsive: true,
-    plugins: {
-      legend: {
-        position: "top" as const,
-      },
-    },
-    scales: {
-      y: {
-        beginAtZero: true,
-        ticks: {
-          stepSize: 1,
-        },
-      },
-    },
-  };
+  // const chartOptions = {
+  //   responsive: true,
+  //   plugins: {
+  //     legend: {
+  //       position: "top" as const,
+  //     },
+  //   },
+  //   scales: {
+  //     y: {
+  //       beginAtZero: true,
+  //       ticks: {
+  //         stepSize: 1,
+  //       },
+  //     },
+  //   },
+  // };
 
   return (
     <Card className="w-full bg-white">
@@ -60,7 +60,7 @@ function MonthlyStats({ monthlyData }: MonthlyStatsProps) {
           <div className="p-4 bg-blue-50 rounded-lg">
             <div className="text-sm text-blue-600 font-medium">당월 평균 운행률</div>
             <div className="text-2xl font-bold text-blue-700">
-              {monthlyData?.avgOperationRate.toFixed(1)}%
+              {/* {monthlyData?.avgOperationRate.toFixed(1)}% */}
             </div>
           </div>
           <div className="p-4 bg-green-50 rounded-lg">
@@ -77,7 +77,7 @@ function MonthlyStats({ monthlyData }: MonthlyStatsProps) {
           </div>
         </div>
         <div className="h-[300px]">
-          <Line data={chartData} options={chartOptions} />
+          {/* <Line data={chartData} options={chartOptions} /> */}
         </div>
       </CardContent>
     </Card>

--- a/src/pages/dashboard/components/MonthlyStats.tsx
+++ b/src/pages/dashboard/components/MonthlyStats.tsx
@@ -20,35 +20,35 @@ interface MonthlyStatsProps {
 }
 
 function MonthlyStats({ monthlyData }: MonthlyStatsProps) {
-  // const chartData = {
-  //   labels: monthlyData?.dailyDriveCount.map((_, index) => `${index + 1}일`),
-  //   datasets: [
-  //     {
-  //       label: "일별 운행 건수",
-  //       data: monthlyData?.dailyDriveCount.map((data) => data),
-  //       borderColor: "rgb(59, 130, 246)",
-  //       backgroundColor: "rgba(59, 130, 246, 0.5)",
-  //       tension: 0.4,
-  //     },
-  //   ],
-  // };
+  const chartData = {
+    labels: monthlyData?.dailyDriveCount.map((_, index) => `${index + 1}일`),
+    datasets: [
+      {
+        label: "일별 운행 건수",
+        data: monthlyData?.dailyDriveCount.map((data) => data),
+        borderColor: "rgb(59, 130, 246)",
+        backgroundColor: "rgba(59, 130, 246, 0.5)",
+        tension: 0.4,
+      },
+    ],
+  };
 
-  // const chartOptions = {
-  //   responsive: true,
-  //   plugins: {
-  //     legend: {
-  //       position: "top" as const,
-  //     },
-  //   },
-  //   scales: {
-  //     y: {
-  //       beginAtZero: true,
-  //       ticks: {
-  //         stepSize: 1,
-  //       },
-  //     },
-  //   },
-  // };
+  const chartOptions = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top" as const,
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          stepSize: 1,
+        },
+      },
+    },
+  };
 
   return (
     <Card className="w-full bg-white">
@@ -77,7 +77,7 @@ function MonthlyStats({ monthlyData }: MonthlyStatsProps) {
           </div>
         </div>
         <div className="h-[300px]">
-          {/* <Line data={chartData} options={chartOptions} /> */}
+          <Line data={chartData} options={chartOptions} />
         </div>
       </CardContent>
     </Card>

--- a/src/pages/statistic/daily/DailyCharts.tsx
+++ b/src/pages/statistic/daily/DailyCharts.tsx
@@ -10,7 +10,6 @@ import {
   Legend,
 } from "chart.js";
 import { Line } from "react-chartjs-2";
-import { dailyHourlyOperationData } from "@/constants/mocks/statisticMockData";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import StatisticDatePicker from "../StatisticDatePicker";

--- a/src/pages/statistic/monthly/MonthlyCharts.tsx
+++ b/src/pages/statistic/monthly/MonthlyCharts.tsx
@@ -34,9 +34,8 @@ function MonthlyCharts({ monthlyData }: MonthlyChartsProps) {
   }
 
   const getMonthlyOperationData = () => {
-    const sortedStat = [...monthlyStat].sort((a, b) => a.month - b.month);
-    const labels = sortedStat.map((item) => `${item.month}월`);
-    const data = sortedStat.map((item) => item.driveCount);
+    const labels = monthlyStat.map((item) => `${item.month}월`);
+    const data = monthlyStat.map((item) => item.driveCount);
 
     return {
       labels,


### PR DESCRIPTION
## 📝작업 내용

백엔드 데이터에 맞춰 interface 및 MockData 수정 (adminStatisticMockData.ts 에 선언해 두었습니다)

CarTypeEnum 추가

adminStatisticApi에 관리자 통계용 API 추가 

관리자 페이지
BizStatisticTable - 업체 목록
BizMonthlyCardStatistic - 업체 선택 후 보이는 업체별 운행 통계 카드
MonthlyDriveCountChart - 월별, 시간별 운행량 그래프
StatisticChart - 종합 통계

VehicleStatisticTable, StatisticCards, DailyStatisticCharts.tsx 는 사용하지 않게 되었으나 일단 남겨두었습니다


### 스크린샷 (선택)
<img width="1440" alt="스크린샷 2025-05-12 오후 2 39 23" src="https://github.com/user-attachments/assets/03a6a870-2313-447e-a5b7-8534e0220c77" />
<img width="1440" alt="스크린샷 2025-05-12 오후 2 41 12" src="https://github.com/user-attachments/assets/dd853833-1849-4e80-a60e-ee909444b4f2" />

